### PR TITLE
fix(build): 빌드 오류 해결을 위해 topbat.html 파일 수정

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -51,7 +51,7 @@
         {% assign main_category = first_post.categories[0] %}
         {% if main_category != page.title %}
           <span>
-            <a href="{{ site.baseurl }}/categories/{{ main_category }}/">
+            <a href="{{ site.baseurl }}/categories/{{ main_category | downcase }}/">
               {{ main_category }}
             </a>
           </span>


### PR DESCRIPTION
> At _site/categories/plugin/index.html:1:
>   internally linking to /categories/Jekyll/, which does not exist

카테고리 주소의 카테고리 이름 첫 글자가 대문자로 설정되어 발생한 오류입니다.
downcase 를 사용하도록 수정하였습니다.