### PR TITLE
fix(build): 빌드 오류 해결을 위해 _config.yml 파일 수정

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -146,7 +146,7 @@ defaults:
       toc: true # Display TOC column in posts.
       # DO NOT modify the following parameter unless you are confident enough
       # to update the code of all other post links in this project.
-      permalink: /posts/:categories/:title/
+      permalink: /posts/:title/
   - scope:
       path: _drafts
     values:


### PR DESCRIPTION
>At _site/posts/jekyll/chirpy/write-a-new-post/index.html:153:
>  internally linking to /posts/text-and-typography/, which does not exist

post url에 카테고리를 추가하도록 설정함으로써 발생한 오류입니다.
처음에 Chirpy 의 Categories 레이아웃에서 url 을 파싱하여 카테고리를 나열하는 방식을 활용하기 위해 도입하였습니다. 그러나 지금은 url 파싱 대신 page.categories 를 활용하기 때문에 기존 설정으로 되돌렸습니다.